### PR TITLE
chore!: remove deprecated init/0 callback and atom metadata key

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,8 +3,8 @@ import Config
 alias Commanded.EventStore.Adapters.InMemory
 alias Commanded.Serialization.JsonSerializer
 
-config :logger, level: :debug
-config :logger, :console, level: :debug, format: "[$level] $message\n"
+config :logger, level: :info
+config :logger, :console, level: :info, format: "[$level] $message\n"
 
 config :ex_unit,
   assert_receive_timeout: 1_000,

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -417,9 +417,6 @@ defmodule Commanded.Event.Handler do
   @type subscribe_from :: :origin | :current | non_neg_integer()
   @type consistency :: :eventual | :strong
 
-  @doc deprecated: "Use the after_start/1 callback instead."
-  @callback init() :: :ok | {:stop, reason :: any()}
-
   @doc """
   Optional initialisation callback function called when the handler starts.
 
@@ -616,8 +613,7 @@ defmodule Commanded.Event.Handler do
   """
   @callback before_reset() :: :ok
 
-  @optional_callbacks init: 0,
-                      init: 1,
+  @optional_callbacks init: 1,
                       error: 3,
                       partition_by: 2,
                       before_reset: 0,
@@ -711,12 +707,7 @@ defmodule Commanded.Event.Handler do
 
       @doc false
       def after_start(_state) do
-        # TODO: remove this when we remove init/0
-        if function_exported?(__MODULE__, :init, 0) do
-          apply(__MODULE__, :init, [])
-        else
-          :ok
-        end
+        :ok
       end
 
       @doc false
@@ -928,10 +919,6 @@ defmodule Commanded.Event.Handler do
     Logger.debug(describe(state) <> " has successfully subscribed to event store")
 
     %Handler{handler_module: handler_module} = state
-
-    if function_exported?(handler_module, :init, 0) do
-      Logger.warning("#{inspect(handler_module)}.init/0 is deprecated, use after_start/1 instead")
-    end
 
     case handler_module.after_start(state.handler_state) do
       :ok ->

--- a/lib/commanded/middleware/pipeline.ex
+++ b/lib/commanded/middleware/pipeline.ex
@@ -9,7 +9,7 @@ defmodule Commanded.Middleware.Pipeline do
   ## Pipeline fields
 
     - `application` - the Commanded application.
-    
+
     - `assigns` - shared user data as a map.
 
     - `causation_id` - an optional UUID used to identify the cause of the
@@ -69,9 +69,9 @@ defmodule Commanded.Middleware.Pipeline do
   @doc """
   Puts the `key` with value equal to `value` into `metadata` map.
 
-  Note: Use of atom keys in metadata is deprecated in favour of binary strings.
+  The key must be a binary string.
   """
-  def assign_metadata(%Pipeline{} = pipeline, key, value) when is_binary(key) or is_atom(key) do
+  def assign_metadata(%Pipeline{} = pipeline, key, value) when is_binary(key) do
     %Pipeline{metadata: metadata} = pipeline
 
     %Pipeline{pipeline | metadata: Map.put(metadata, key, value)}

--- a/test/aggregates/aggregate_test.exs
+++ b/test/aggregates/aggregate_test.exs
@@ -38,12 +38,13 @@ defmodule Commanded.Aggregates.AggregateTest do
 
     test "ignore unexpected messages", %{pid: pid, ref: ref} do
       send_unexpected_mesage = fn ->
+        Logger.configure(level: :debug)
         send(pid, :unexpected_message)
 
         refute_receive {:DOWN, ^ref, :process, ^pid, _reason}
       end
 
-      captured = capture_log(send_unexpected_mesage)
+      captured = capture_log([level: :debug], send_unexpected_mesage)
 
       assert captured =~ "received unexpected message in handle_info/2: :unexpected_message"
     end

--- a/test/event/handler_init_test.exs
+++ b/test/event/handler_init_test.exs
@@ -1,11 +1,8 @@
 defmodule Commanded.Event.HandlerInitTest do
   use Commanded.MockEventStoreCase
 
-  import Mox
-
   alias Commanded.DefaultApp
-  alias Commanded.Event.{EchoHandler, Handler, InitHandler, ReplyEvent, RuntimeConfigHandler}
-  alias Commanded.EventStore.Adapters.Mock, as: MockEventStore
+  alias Commanded.Event.{EchoHandler, Handler, ReplyEvent, RuntimeConfigHandler}
   alias Commanded.Helpers.{EventFactory, Wait}
 
   describe "event handler `init/1` callback" do
@@ -43,31 +40,6 @@ defmodule Commanded.Event.HandlerInitTest do
       assert_receive {:init, :tenant1}
       assert_receive {:init, :tenant1}
       refute_receive {:init, :tenant1}
-    end
-  end
-
-  describe "event handler `init/0` callback" do
-    setup do
-      true = Process.register(self(), :test)
-
-      expect(MockEventStore, :subscribe_to, fn
-        _event_store, :all, handler_name, handler, _subscribe_from, _opts ->
-          assert is_binary(handler_name)
-
-          {:ok, handler}
-      end)
-
-      handler = start_supervised!(InitHandler)
-
-      [handler: handler]
-    end
-
-    test "should be called after subscription subscribed", %{handler: handler} do
-      refute_receive {:init, ^handler}
-
-      send_subscribed(handler)
-
-      assert_receive {:init, ^handler}
     end
   end
 
@@ -120,10 +92,6 @@ defmodule Commanded.Event.HandlerInitTest do
     post_otp_28 = {:current_function, {:gen_server, :loop_hibernate, 4}}
 
     assert Process.info(pid, :current_function) in [pre_otp_28, post_otp_28]
-  end
-
-  defp send_subscribed(handler) do
-    send(handler, {:subscribed, handler})
   end
 
   defp send_events(handler, events) do

--- a/test/event/support/init/init_handler.ex
+++ b/test/event/support/init/init_handler.ex
@@ -1,9 +1,0 @@
-defmodule Commanded.Event.InitHandler do
-  use Commanded.Event.Handler,
-    application: Commanded.MockedApp,
-    name: __MODULE__
-
-  def init do
-    Process.send(:test, {:init, self()}, [])
-  end
-end

--- a/test/event_handler_after_start_test.exs
+++ b/test/event_handler_after_start_test.exs
@@ -2,7 +2,6 @@ defmodule Commanded.Event.HandlerAfterStartTest do
   use Commanded.MockEventStoreCase
 
   import Mox
-  import ExUnit.CaptureLog
 
   alias Commanded.EventStore.Adapters.Mock, as: MockEventStore
 
@@ -13,47 +12,6 @@ defmodule Commanded.Event.HandlerAfterStartTest do
     end)
 
     :ok
-  end
-
-  describe "event handler `init/0` callback" do
-    # TODO: remove these test when we remove init/0
-
-    setup(%{test: test}) do
-      # HACK: generate a module that can communicate back to our test process
-      true = Process.register(self(), test)
-
-      Code.eval_string("""
-        defmodule DeprecatedHandler do
-          use Commanded.Event.Handler,
-            application: Commanded.MockedApp,
-            name: __MODULE__
-
-          @impl Commanded.Event.Handler
-          def init() do
-            process_name = :"#{test}"
-            Process.send(process_name, {:init, self()}, [])
-          end
-        end
-      """)
-
-      [handler: start_supervised!(DeprecatedHandler)]
-    end
-
-    test "should be called and a deprecation warning raised after handler subscribbed", %{
-      handler: handler
-    } do
-      warning =
-        capture_log([level: :warning], fn ->
-          # When the handler subscribes to the eventstore
-          send_subscribed(handler)
-
-          # Then we expect init/0 to have been called for us
-          assert_receive {:init, ^handler}
-        end)
-
-      # And we expect a deprecation warning to have been logged
-      assert warning =~ "DeprecatedHandler.init/0 is deprecated, use after_start/1 instead"
-    end
   end
 
   describe "event handler `after_start/1` callback" do

--- a/test/example_domain/bank_account/bank_account_batch_handler.ex
+++ b/test/example_domain/bank_account/bank_account_batch_handler.ex
@@ -7,22 +7,27 @@ defmodule Commanded.ExampleDomain.BankAccount.BankAccountBatchHandler do
     start_from: :origin,
     batch_size: 3
 
+  alias Commanded.Event.Handler
   alias Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened
 
-  def init do
+  @impl Handler
+  def after_start(_state) do
     case Agent.start_link(fn -> %{prefix: "", accounts: []} end, name: __MODULE__) do
       {:ok, _} -> :ok
       {:error, {:already_started, _}} -> :ok
-      _ -> {:error, :unable_to_start}
+      _ -> {:stop, :unable_to_start}
     end
   end
 
+  @impl Handler
   def before_reset do
     Agent.update(__MODULE__, fn state -> %{state | accounts: []} end)
   end
 
+  @impl Handler
   def handle_batch([]), do: :ok
 
+  @impl Handler
   def handle_batch([{%BankAccountOpened{} = event, _metadata} | rest]) do
     %BankAccountOpened{account_number: account_number} = event
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove deprecated `init/0` callback across handler and tests; enforce binary metadata keys in Pipeline; update example handler and test configurations.
> 
> - **Event Handling**:
>   - Remove all support for deprecated `init/0` in `Commanded.Event.Handler` (callback, invocation, warnings, and optional callbacks).
>   - Keep `after_start/1` as the initialization path; subscribed flow now calls only `after_start/1`.
> - **Middleware**:
>   - Enforce binary metadata keys in `Commanded.Middleware.Pipeline.assign_metadata/3` (docs and guard updated).
> - **Examples**:
>   - Replace `init/0` with `after_start/1` in `BankAccountBatchHandler`; return `{:stop, reason}` on failure; add `@impl` annotations.
> - **Tests**:
>   - Remove tests and support module for deprecated `init/0`.
>   - Add/adjust tests for `after_start/1`; tweak log capture levels where needed.
> - **Config**:
>   - Set test logger level to `:info` (from `:debug`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 228399eab0577aba62b7098755eb735dbf9d1b35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->