### PR TITLE
chore: enhance logging for `after_start/1` callback to include stop reason

### DIFF
--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -929,7 +929,9 @@ defmodule Commanded.Event.Handler do
         {:noreply, new_state}
 
       {:stop, reason} ->
-        Logger.debug(describe(state) <> " `after_start/1` callback has requested to stop")
+        Logger.info(
+          describe(state) <> " `after_start/1` callback has requested to stop: #{inspect(reason)}"
+        )
 
         {:stop, reason, state}
     end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> When `after_start/1` returns `{:stop, reason}`, log at info level and include the stop reason.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cac8d39aff95b460852e7abc259b682ece3a75ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->