### PR TITLE
chore: sync upstream changes with conventional commits

### DIFF
--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -67,17 +67,9 @@ defmodule Commanded.Commands.Dispatcher do
     struct(Pipeline, Map.from_struct(payload))
   end
 
-  # Ignoring this dialyzer warning until dialyxir catches up on Elixir 1.18.x-otp-28
+  # FIXME: Elixir 1.18.x-otp-28
   # Please file a bug in https://github.com/jeremyjh/dialyxir/issues with this message.
-  # Unknown error occurred:
-  #   %FunctionClauseError{
-  #     module: Dialyxir.Warnings.CallWithoutOpaque,
-  #     function: :format_long,
-  #     arity: 1,
-  #     kind: nil,
-  #     args: nil,
-  #     clauses: nil
-  #   }
+  # Unknown error occurred: %FunctionClauseError{module: Dialyxir.Warnings.CallWithoutOpaque, function: :format_long, arity: 1, kind: nil, args: nil, clauses: nil}
   # Open issue in dialyxir:
   # https://github.com/jeremyjh/dialyxir/issues/568
   @dialyzer {:nowarn_function, execute: 3}

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -67,8 +67,10 @@ defmodule Commanded.Commands.Dispatcher do
     struct(Pipeline, Map.from_struct(payload))
   end
 
+  # credo:disable-for-next-line Credo.Check.Design.TagFIXME
   # FIXME: Elixir 1.18.x-otp-28
   # Please file a bug in https://github.com/jeremyjh/dialyxir/issues with this message.
+  # credo:disable-for-next-line Credo.Check.Readability.MaxLineLength
   # Unknown error occurred: %FunctionClauseError{module: Dialyxir.Warnings.CallWithoutOpaque, function: :format_long, arity: 1, kind: nil, args: nil, clauses: nil}
   # Open issue in dialyxir:
   # https://github.com/jeremyjh/dialyxir/issues/568

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -667,17 +667,21 @@ defmodule Commanded.Commands.Router do
   ]
 
   defp parse_opts(opts) do
+    # Check for duplicate keys before popping
+    Enum.each([:to, :aggregate, :function], fn key ->
+      case Keyword.get_values(opts, key) do
+        [_, _ | _] ->
+          raise ArgumentError,
+                "duplicate dispatch parameter \"#{key}\" - only one value allowed"
+
+        _ ->
+          :ok
+      end
+    end)
+
     {to, opts} = Keyword.pop(opts, :to)
     {aggregate, opts} = Keyword.pop(opts, :aggregate)
     {function, opts} = Keyword.pop(opts, :function)
-
-    # Check for duplicate keys that would be silently merged
-    Enum.each([:to, :aggregate, :function], fn key ->
-      if Keyword.has_key?(opts, key) do
-        raise ArgumentError,
-              "duplicate dispatch parameter \"#{key}\" - only one value allowed"
-      end
-    end)
 
     with {unknown_param, _} <- Enum.find(opts, fn {param, _} -> param not in @register_params end) do
       raise ArgumentError, """

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -671,6 +671,14 @@ defmodule Commanded.Commands.Router do
     {aggregate, opts} = Keyword.pop(opts, :aggregate)
     {function, opts} = Keyword.pop(opts, :function)
 
+    # Check for duplicate keys that would be silently merged
+    Enum.each([:to, :aggregate, :function], fn key ->
+      if Keyword.has_key?(opts, key) do
+        raise ArgumentError,
+              "duplicate dispatch parameter \"#{key}\" - only one value allowed"
+      end
+    end)
+
     with {unknown_param, _} <- Enum.find(opts, fn {param, _} -> param not in @register_params end) do
       raise """
       unexpected dispatch parameter "#{unknown_param}"

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -680,7 +680,7 @@ defmodule Commanded.Commands.Router do
     end)
 
     with {unknown_param, _} <- Enum.find(opts, fn {param, _} -> param not in @register_params end) do
-      raise """
+      raise ArgumentError, """
       unexpected dispatch parameter "#{unknown_param}"
       available params are: #{Enum.map_join(@register_params, ", ", &to_string/1)}
       """
@@ -688,7 +688,7 @@ defmodule Commanded.Commands.Router do
 
     case {to, aggregate} do
       {nil, _aggregate} ->
-        raise "dispatch missing required parameter: :to"
+        raise ArgumentError, "dispatch missing required parameter: :to"
 
       {to, nil} ->
         function = function || :execute

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -338,6 +338,17 @@ defmodule Commanded.Event.Handler do
   have processed all events produced by the command: if event handling fails
   the events will have still been persisted.
 
+  ### Example
+
+  Define an event handler with `:strong` consistency:
+
+      defmodule ExampleHandler do
+        use Commanded.Event.Handler,
+          application: ExampleApp,
+          name: "ExampleHandler",
+          consistency: :strong
+      end
+
   ## Batching
 
   Sometimes, it is more efficient to process a whole batch of events, write them
@@ -356,17 +367,6 @@ defmodule Commanded.Event.Handler do
 
   Batching and concurrency currently are not supported together; setting conflicting
   options will trigger a compilation error.
-
-  ### Example
-
-  Define an event handler with `:strong` consistency:
-
-      defmodule ExampleHandler do
-        use Commanded.Event.Handler,
-          application: ExampleApp,
-          name: "ExampleHandler",
-          consistency: :strong
-      end
 
   ## Dynamic application
 

--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -96,6 +96,7 @@ defmodule Commanded.EventStore.Adapters.InMemory do
       concurrency_limit: Keyword.get(opts, :concurrency_limit),
       name: subscription_name,
       partition_by: Keyword.get(opts, :partition_by),
+      selector: Keyword.get(opts, :selector),
       start_from: start_from,
       stream_uuid: stream_uuid
     }
@@ -500,19 +501,37 @@ defmodule Commanded.EventStore.Adapters.InMemory do
 
     position = if checkpoint == 0, do: -1, else: -(checkpoint + 1)
 
-    case Enum.at(events, position) do
-      %RecordedEvent{} = unseen_event ->
-        unseen_event =
-          deserialize(state, unseen_event) |> set_event_number_from_version(stream_uuid)
+    unseen_event =
+      with %RecordedEvent{} = event <- Enum.at(events, position) do
+        state
+        |> deserialize(event)
+        |> set_event_number_from_version(stream_uuid)
+      end
 
+    cond do
+      is_nil(unseen_event) ->
+        subscription
+
+      unseen_event && selected?(unseen_event, subscription) ->
         case PersistentSubscription.publish(subscription, unseen_event) do
           {:ok, subscription} -> publish_events(state, subscription)
           {:error, :no_subscriber_available} -> subscription
         end
 
-      nil ->
-        subscription
+      unseen_event ->
+        %RecordedEvent{event_number: event_number} = unseen_event
+        subscription = PersistentSubscription.checkpoint(subscription, event_number)
+        publish_events(state, subscription)
     end
+  end
+
+  defp selected?(event, %PersistentSubscription{selector: selector})
+       when is_function(selector, 1) do
+    selector.(event)
+  end
+
+  defp selected?(_event, %PersistentSubscription{}) do
+    true
   end
 
   defp stop_subscription(%State{} = state, subscription) do

--- a/lib/commanded/event_store/adapters/in_memory/persistent_subscription.ex
+++ b/lib/commanded/event_store/adapters/in_memory/persistent_subscription.ex
@@ -11,6 +11,7 @@ defmodule Commanded.EventStore.Adapters.InMemory.PersistentSubscription do
     :name,
     :partition_by,
     :ref,
+    :selector,
     :start_from,
     :stream_uuid,
     subscribers: []
@@ -116,6 +117,13 @@ defmodule Commanded.EventStore.Adapters.InMemory.PersistentSubscription do
     else
       subscription
     end
+  end
+
+  @doc """
+  Set the checkpoint for a subscriber.
+  """
+  def checkpoint(%PersistentSubscription{} = subscription, checkpoint) do
+    %PersistentSubscription{subscription | checkpoint: checkpoint}
   end
 
   # Get the subscriber to send the event to determined by the partition function

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -43,10 +43,11 @@ defmodule Commanded.Commands.RoutingCommandsTest do
     defmodule CommandHandlerRouter do
       use Commanded.Commands.Router
 
+      # Put the :to option at the end and ensure the dispatch still works
       dispatch OpenAccount,
-        to: OpenAccountHandler,
         aggregate: BankAccount,
-        identity: :account_number
+        identity: :account_number,
+        to: OpenAccountHandler
 
       dispatch DepositMoney,
         to: DepositMoneyHandler,
@@ -54,7 +55,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
         identity: :account_number
     end
 
-    test "should dispatch command to registered handler" do
+    test "should dispatch command to registered handler, regardless of the router dispatch option order" do
       assert :ok =
                CommandHandlerRouter.dispatch(
                  %OpenAccount{
@@ -240,6 +241,21 @@ defmodule Commanded.Commands.RoutingCommandsTest do
                      end
                    """)
                  end
+  end
+
+  test "should show a helpful message when required :to argument is missing" do
+    assert_raise RuntimeError, "dispatch missing required parameter: :to", fn ->
+      Code.eval_string("""
+        alias Commanded.ExampleDomain.BankAccount
+        alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+
+        defmodule InvalidRouter do
+          use Commanded.Commands.Router
+
+          dispatch OpenAccount, identity: BankAccount
+        end
+      """)
+    end
   end
 
   defmodule MultiCommandRouter do

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -224,7 +224,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   end
 
   test "should show a helpful message when bad argument given to a `dispatch/2` function" do
-    assert_raise RuntimeError,
+    assert_raise ArgumentError,
                  """
                  unexpected dispatch parameter "id"
                  available params are: to, function, before_execute, aggregate, identity, identity_prefix, timeout, lifespan, consistency
@@ -244,7 +244,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   end
 
   test "should show a helpful message when required :to argument is missing" do
-    assert_raise RuntimeError, "dispatch missing required parameter: :to", fn ->
+    assert_raise ArgumentError, "dispatch missing required parameter: :to", fn ->
       Code.eval_string("""
         alias Commanded.ExampleDomain.BankAccount
         alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
@@ -354,6 +354,74 @@ defmodule Commanded.Commands.RoutingCommandsTest do
         application: DefaultApp,
         metadata: metadata
       )
+    end
+  end
+
+  describe "duplicate dispatch options" do
+    test "should reject duplicate :to option" do
+      assert_raise ArgumentError,
+                   ~r/duplicate dispatch parameter "to" - only one value allowed/,
+                   fn ->
+                     Code.eval_string("""
+                       alias Commanded.ExampleDomain.BankAccount
+                       alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+                       alias Commanded.ExampleDomain.OpenAccountHandler
+                       alias Commanded.ExampleDomain.DepositMoneyHandler
+
+                       defmodule DuplicateToRouter do
+                         use Commanded.Commands.Router
+
+                         dispatch OpenAccount,
+                           to: OpenAccountHandler,
+                           to: DepositMoneyHandler,
+                           identity: :account_number
+                       end
+                     """)
+                   end
+    end
+
+    test "should reject duplicate :aggregate option" do
+      assert_raise ArgumentError,
+                   ~r/duplicate dispatch parameter "aggregate" - only one value allowed/,
+                   fn ->
+                     Code.eval_string("""
+                       alias Commanded.ExampleDomain.BankAccount
+                       alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+                       alias Commanded.ExampleDomain.OpenAccountHandler
+                       alias Commanded.Commands.AggregateRoot
+
+                       defmodule DuplicateAggregateRouter do
+                         use Commanded.Commands.Router
+
+                         dispatch OpenAccount,
+                           to: OpenAccountHandler,
+                           aggregate: BankAccount,
+                           aggregate: AggregateRoot,
+                           identity: :account_number
+                       end
+                     """)
+                   end
+    end
+
+    test "should reject duplicate :function option" do
+      assert_raise ArgumentError,
+                   ~r/duplicate dispatch parameter "function" - only one value allowed/,
+                   fn ->
+                     Code.eval_string("""
+                       alias Commanded.ExampleDomain.BankAccount
+                       alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+
+                       defmodule DuplicateFunctionRouter do
+                         use Commanded.Commands.Router
+
+                         dispatch OpenAccount,
+                           to: BankAccount,
+                           function: :execute,
+                           function: :handle,
+                           identity: :account_number
+                       end
+                     """)
+                   end
     end
   end
 end


### PR DESCRIPTION
## Summary

Synced 4 commits from upstream with proper conventional commit messages and preserved original authors.

## Changes

- fix: improve router registration error messages (#644)
- docs: fix event handler documentation
- feat: add selector option support for InMemory adapter (#647)
- chore: suppress CallWithoutOpaque warning

## Authors

- Tyler Pachal (@TylerPachal)
- drteeth (@drteeth)

All commits follow Conventional Commits and preserve original authorship.