### PR TITLE
fix: enable event store OpenTelemetry tracing by default

### DIFF
--- a/lib/commanded/opentelemetry.ex
+++ b/lib/commanded/opentelemetry.ex
@@ -89,9 +89,8 @@ defmodule Commanded.OpenTelemetry do
                    ],
                    event_store: [
                      type: {:in, [:disabled, []]},
-                     default: :disabled,
-                     doc:
-                       "Event store tracing configuration. Disabled by default. Use `[]` to enable."
+                     default: [],
+                     doc: "Event store tracing configuration. Use `:disabled` to disable."
                    ]
                  )
 
@@ -106,7 +105,7 @@ defmodule Commanded.OpenTelemetry do
 
   ## Examples
 
-      # Default setup (enables all tracing except event_store)
+      # Default setup (enables all tracing)
       Commanded.OpenTelemetry.setup()
 
       # Disable aggregate tracing
@@ -121,8 +120,8 @@ defmodule Commanded.OpenTelemetry do
       # Disable aggregate populate tracing
       Commanded.OpenTelemetry.setup(aggregate_populate: :disabled)
 
-      # Enable event store tracing (disabled by default)
-      Commanded.OpenTelemetry.setup(event_store: [])
+      # Disable event store tracing
+      Commanded.OpenTelemetry.setup(event_store: :disabled)
 
       # Use parent-child relationships for event handlers
       Commanded.OpenTelemetry.setup(event_handler: [span_relationship: :child])


### PR DESCRIPTION
## Summary

- The `event_store` option in `Commanded.OpenTelemetry.setup/1` was the only tracing module disabled by default (`:disabled`), while all other modules (aggregate, aggregate_populate, application, event_handler) default to enabled (`[]`).
- Changed the default to `[]` so all OTEL tracing is enabled consistently when calling `setup/0`.
- Updated docs and examples to reflect the new default.

## Test plan

- [x] `mix test test/opentelemetry/event_store_test.exs` — all 15 tests pass
- [x] `mix compile --warnings-as-errors` — clean compilation