### PR TITLE
feat(telemetry): add registry adapter to aggregate execute span

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -13,7 +13,8 @@ defmodule Commanded.Aggregates.Aggregate do
       aggregate_state: struct(),
       aggregate_version: non_neg_integer(),
       caller: pid(),
-      execution_context: Commanded.Aggregates.ExecutionContext.t()}
+      execution_context: Commanded.Aggregates.ExecutionContext.t(),
+      registry_adapter: module()}
     """
   })
 
@@ -28,6 +29,7 @@ defmodule Commanded.Aggregates.Aggregate do
       aggregate_version: non_neg_integer(),
       caller: pid(),
       execution_context: Commanded.Aggregates.ExecutionContext.t(),
+      registry_adapter: module(),
       events: [map()],
       error: nil | any(),
       wrong_expected_version_count: non_neg_integer()}
@@ -769,6 +771,8 @@ defmodule Commanded.Aggregates.Aggregate do
 
     {pid, _ref} = from
 
+    {registry_adapter, _} = Commanded.Application.registry_adapter(application)
+
     %{
       application: application,
       aggregate_uuid: aggregate_uuid,
@@ -776,6 +780,7 @@ defmodule Commanded.Aggregates.Aggregate do
       aggregate_version: aggregate_version,
       caller: pid,
       execution_context: context,
+      registry_adapter: registry_adapter,
       wrong_expected_version_count: wrong_expected_version_count
     }
   end

--- a/lib/commanded/opentelemetry/aggregate.ex
+++ b/lib/commanded/opentelemetry/aggregate.ex
@@ -58,7 +58,9 @@ defmodule Commanded.OpenTelemetry.Aggregate do
       {CommandedAttributes.commanded_aggregate_version(), meta.aggregate_version},
       {CommandedAttributes.commanded_command(), Helpers.struct_name(context.command)},
       {CommandedAttributes.commanded_correlation_id(), context.correlation_id},
-      {CommandedAttributes.commanded_causation_id(), context.causation_id}
+      {CommandedAttributes.commanded_causation_id(), context.causation_id},
+      {CommandedAttributes.commanded_registry_adapter(),
+       Helpers.module_name(meta.registry_adapter)}
     ]
 
     # OTel semconv: span name = "{operation.name} {destination.name}"

--- a/lib/commanded/opentelemetry/commanded_attributes.ex
+++ b/lib/commanded/opentelemetry/commanded_attributes.ex
@@ -178,4 +178,10 @@ defmodule Commanded.OpenTelemetry.CommandedAttributes do
   """
   @spec commanded_handler_lag() :: :"commanded.handler.lag"
   def commanded_handler_lag, do: :"commanded.handler.lag"
+
+  @doc """
+  The process registry adapter module (e.g. Commanded.Registration.GlobalRegistry).
+  """
+  @spec commanded_registry_adapter() :: :"commanded.registry.adapter"
+  def commanded_registry_adapter, do: :"commanded.registry.adapter"
 end

--- a/test/opentelemetry/aggregate_test.exs
+++ b/test/opentelemetry/aggregate_test.exs
@@ -113,6 +113,7 @@ defmodule Commanded.OpenTelemetry.AggregateTest do
                "commanded.command": "Commanded.TestSupport.TestDomain.OpenAccount",
                "commanded.correlation_id": correlation_id,
                "commanded.causation_id": causation_id,
+               "commanded.registry.adapter": "Commanded.Registration.LocalRegistry",
                "commanded.event.count": 0
              }
     end
@@ -161,6 +162,7 @@ defmodule Commanded.OpenTelemetry.AggregateTest do
                "commanded.command": "Commanded.Middleware.Commands.IncrementCount",
                "commanded.causation_id": causation_id,
                "commanded.correlation_id": correlation_id,
+               "commanded.registry.adapter": "Commanded.Registration.LocalRegistry",
                "commanded.event.count": 1
              }
     end
@@ -223,6 +225,7 @@ defmodule Commanded.OpenTelemetry.AggregateTest do
                "commanded.command": "Commanded.Middleware.Commands.IncrementCount",
                "commanded.causation_id": causation_id1,
                "commanded.correlation_id": correlation_id1,
+               "commanded.registry.adapter": "Commanded.Registration.LocalRegistry",
                "commanded.event.count": 1
              }
 
@@ -256,6 +259,7 @@ defmodule Commanded.OpenTelemetry.AggregateTest do
                "commanded.command": "Commanded.Middleware.Commands.IncrementCount",
                "commanded.causation_id": causation_id2,
                "commanded.correlation_id": correlation_id2,
+               "commanded.registry.adapter": "Commanded.Registration.LocalRegistry",
                "commanded.event.count": 1
              }
     end
@@ -314,6 +318,7 @@ defmodule Commanded.OpenTelemetry.AggregateTest do
                "commanded.command": "Commanded.TestSupport.TestDomain.OpenAccount",
                "commanded.correlation_id": correlation_id,
                "commanded.causation_id": causation_id,
+               "commanded.registry.adapter": "Commanded.Registration.LocalRegistry",
                "commanded.event.count": 0,
                "error.type": "validation_failed"
              }
@@ -359,6 +364,7 @@ defmodule Commanded.OpenTelemetry.AggregateTest do
                "commanded.command": "Commanded.TestSupport.TestDomain.OpenAccount",
                "commanded.correlation_id": context.correlation_id,
                "commanded.causation_id": context.causation_id,
+               "commanded.registry.adapter": "Commanded.Registration.LocalRegistry",
                "erlang.exception.kind": :error,
                "error.type": "Elixir.ArgumentError"
              }
@@ -404,6 +410,7 @@ defmodule Commanded.OpenTelemetry.AggregateTest do
                "commanded.command": "Commanded.TestSupport.TestDomain.OpenAccount",
                "commanded.correlation_id": context.correlation_id,
                "commanded.causation_id": context.causation_id,
+               "commanded.registry.adapter": "Commanded.Registration.LocalRegistry",
                "erlang.exception.kind": :error,
                "error.type": "Elixir.RuntimeError"
              }
@@ -596,6 +603,7 @@ defmodule Commanded.OpenTelemetry.AggregateTest do
                "commanded.command": "Commanded.TestSupport.TestDomain.OpenAccount",
                "commanded.correlation_id": correlation_id,
                "commanded.causation_id": causation_id,
+               "commanded.registry.adapter": "Commanded.Registration.LocalRegistry",
                "commanded.event.count": 0
              }
     end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -573,7 +573,8 @@ defmodule Commanded.TestSupport.Factory do
       aggregate_state: Keyword.fetch!(opts, :aggregate_state),
       aggregate_version: Keyword.fetch!(opts, :aggregate_version),
       caller: Keyword.fetch!(opts, :caller),
-      execution_context: Keyword.fetch!(opts, :execution_context)
+      execution_context: Keyword.fetch!(opts, :execution_context),
+      registry_adapter: Keyword.get(opts, :registry_adapter, Commanded.Registration.LocalRegistry)
     }
   end
 


### PR DESCRIPTION
- When using `:global` registry, the registry adapter introduces per-call distributed lookup latency that is otherwise invisible in traces — surfacing the adapter on every `execute` span makes it possible to filter and compare latency by registry type in observability tooling