### PR TITLE
fix(types): prevent invalid dispatch metadata from bypassing Dialyzer

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -366,7 +366,7 @@ defmodule Commanded.Application do
   """
   @callback dispatch(
               command :: struct(),
-              timeout_or_opts :: non_neg_integer() | :infinity | Keyword.t()
+              timeout_or_opts :: non_neg_integer() | :infinity | Router.dispatch_options()
             ) :: Router.dispatch_resp()
 
   @doc false

--- a/lib/commanded/commands/composite_router.ex
+++ b/lib/commanded/commands/composite_router.ex
@@ -98,7 +98,7 @@ defmodule Commanded.Commands.CompositeRouter do
       """
       @spec dispatch(
               command :: struct(),
-              timeout_or_opts :: non_neg_integer() | :infinity | Keyword.t()
+              timeout_or_opts :: non_neg_integer() | :infinity | Router.dispatch_options()
             ) :: Router.dispatch_resp()
       def dispatch(command, opts \\ [])
 

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -388,6 +388,27 @@ defmodule Commanded.Commands.Router do
           | {:error, :consistency_timeout}
           | {:error, reason :: term()}
 
+  @type dispatch_consistency ::
+          :eventual | :strong | [module() | String.t()]
+
+  @type dispatch_return ::
+          :aggregate_state | :aggregate_version | :events | :execution_result | false
+
+  @type dispatch_option ::
+          {:application, Commanded.Application.t()}
+          | {:causation_id, String.t() | nil}
+          | {:command_uuid, String.t()}
+          | {:consistency, dispatch_consistency()}
+          | {:correlation_id, String.t() | nil}
+          | {:include_aggregate_version, boolean()}
+          | {:include_execution_result, boolean()}
+          | {:metadata, map()}
+          | {:returning, dispatch_return()}
+          | {:retry_attempts, non_neg_integer() | nil}
+          | {:timeout, non_neg_integer() | :infinity}
+
+  @type dispatch_options :: [dispatch_option()]
+
   @doc """
   Dispatch the given command to the registered handler.
 
@@ -475,7 +496,7 @@ defmodule Commanded.Commands.Router do
   """
   @callback dispatch(
               command :: struct(),
-              timeout_or_opts :: non_neg_integer() | :infinity | Keyword.t()
+              timeout_or_opts :: non_neg_integer() | :infinity | dispatch_options()
             ) :: dispatch_resp()
 
   defmacro __before_compile__(_env) do

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -383,6 +383,7 @@ defmodule Commanded.Commands.Router do
           :ok
           | {:ok, aggregate_state :: struct()}
           | {:ok, aggregate_version :: non_neg_integer()}
+          | {:ok, events :: [struct()]}
           | {:ok, execution_result :: ExecutionResult.t()}
           | {:error, :unregistered_command}
           | {:error, :consistency_timeout}


### PR DESCRIPTION
- Tightens the public dispatch contract so invalid metadata shapes are visible to static analysis before they fail at runtime
- Keeps the documented API expectation for dispatch metadata aligned with the exposed typespecs instead of hiding it behind a generic keyword list