### PR TITLE
fix(dispatch): reduce drift in the public return contract

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -342,6 +342,9 @@ defmodule Commanded.Application do
             - `:aggregate_version` - to include the aggregate stream version
               in the successful response: `{:ok, aggregate_version}`.
 
+            - `:events` - to return the resultant domain events. An empty list
+              will be returned if no events were produced.
+
             - `:execution_result` - to return a `Commanded.Commands.ExecutionResult`
               struct containing the aggregate's identity, version, and any
               events produced from the command along with their associated
@@ -352,8 +355,8 @@ defmodule Commanded.Application do
         - `timeout` - as described above.
 
   Returns `:ok` on success unless the `:returning` option is specified where
-  it returns one of `{:ok, aggregate_state}`, `{:ok, aggregate_version}`, or
-  `{:ok, %Commanded.Commands.ExecutionResult{}}`.
+  it returns one of `{:ok, aggregate_state}`, `{:ok, aggregate_version}`,
+  `{:ok, events}`, or `{:ok, %Commanded.Commands.ExecutionResult{}}`.
 
   Returns `{:error, reason}` on failure.
 

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -37,8 +37,7 @@ defmodule Commanded.Commands.Dispatcher do
 
   # Dispatch the given command to the handler module for the aggregate as
   # identified.
-  @spec dispatch(payload :: Payload.t()) ::
-          Router.dispatch_resp() | {:ok, events :: list(struct())}
+  @spec dispatch(payload :: Payload.t()) :: Router.dispatch_resp()
   def dispatch(%Payload{} = payload) do
     pipeline = to_pipeline(payload)
     telemetry_metadata = telemetry_metadata(pipeline, payload)

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -483,8 +483,8 @@ defmodule Commanded.Commands.Router do
         - `timeout` - as described above.
 
   Returns `:ok` on success unless the `:returning` option is specified where
-  it returns one of `{:ok, aggregate_state}`, `{:ok, aggregate_version}`, or
-  `{:ok, %Commanded.Commands.ExecutionResult{}}`.
+  it returns one of `{:ok, aggregate_state}`, `{:ok, aggregate_version}`,
+  `{:ok, events}`, or `{:ok, %Commanded.Commands.ExecutionResult{}}`.
 
   Returns `{:error, reason}` on failure.
 


### PR DESCRIPTION
- Keeps the application docs, router docs, and dispatcher types aligned so supported return modes are described consistently
- Reduces avoidable ambiguity in the public dispatch contract that can otherwise leak into tooling and downstream integrations