### PR TITLE
fix(types): strengthen dispatch struct contracts for Dialyzer

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -166,6 +166,7 @@ defmodule Commanded.Application do
   """
 
   @type t :: module
+  @type app_ref :: t | atom
   @type options :: [name: nil | atom]
 
   @doc false

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -11,7 +11,41 @@ defmodule Commanded.Commands.Dispatcher do
   defmodule Payload do
     @moduledoc false
 
-    @type t :: %Payload{}
+    @type t :: %__MODULE__{
+            application: Commanded.Application.app_ref(),
+            command: struct(),
+            command_uuid: String.t(),
+            causation_id: String.t() | nil,
+            correlation_id: String.t() | nil,
+            consistency: Router.dispatch_consistency(),
+            handler_module: module(),
+            handler_function: atom(),
+            handler_before_execute: nil | atom(),
+            aggregate_module: module(),
+            identity: atom() | (struct() -> term()),
+            identity_prefix: nil | String.t() | (-> String.t()),
+            timeout: non_neg_integer() | :infinity,
+            lifespan: module(),
+            metadata: map(),
+            retry_attempts: non_neg_integer() | nil,
+            returning: Router.dispatch_return(),
+            middleware: [module()]
+          }
+
+    @enforce_keys [
+      :application,
+      :command,
+      :command_uuid,
+      :consistency,
+      :handler_module,
+      :handler_function,
+      :aggregate_module,
+      :identity,
+      :timeout,
+      :lifespan,
+      :metadata,
+      :returning
+    ]
 
     defstruct [
       :application,

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -396,7 +396,7 @@ defmodule Commanded.Commands.Router do
           :aggregate_state | :aggregate_version | :events | :execution_result | false
 
   @type dispatch_option ::
-          {:application, Commanded.Application.t()}
+          {:application, Commanded.Application.app_ref()}
           | {:causation_id, String.t() | nil}
           | {:command_uuid, String.t()}
           | {:consistency, dispatch_consistency()}

--- a/lib/commanded/middleware/middleware.ex
+++ b/lib/commanded/middleware/middleware.ex
@@ -41,7 +41,7 @@ defmodule Commanded.Middleware do
 
   alias Commanded.Middleware.Pipeline
 
-  @type pipeline :: %Pipeline{}
+  @type pipeline :: Pipeline.t()
 
   @callback before_dispatch(pipeline) :: pipeline
   @callback after_dispatch(pipeline) :: pipeline

--- a/lib/commanded/middleware/pipeline.ex
+++ b/lib/commanded/middleware/pipeline.ex
@@ -40,6 +40,21 @@ defmodule Commanded.Middleware.Pipeline do
     - `response` - sets the response to send back to the caller.
 
   """
+  @type t :: %__MODULE__{
+          application: Commanded.Application.app_ref() | nil,
+          causation_id: String.t() | nil,
+          correlation_id: String.t() | nil,
+          command: struct() | nil,
+          command_uuid: String.t() | nil,
+          consistency: Commanded.Commands.Router.dispatch_consistency() | nil,
+          identity: (atom() | (struct() -> term())) | nil,
+          identity_prefix: nil | String.t() | (-> String.t()),
+          metadata: map() | nil,
+          response: term() | nil,
+          assigns: map(),
+          halted: boolean()
+        }
+
   defstruct [
     :application,
     :causation_id,


### PR DESCRIPTION
- Makes more of the dispatch pipeline visible to static analysis so contract drift is caught earlier without adding more runtime checks
- Aligns the typed dispatch surface with real usage, including named application atoms and the middleware pipeline struct shape