### PR TITLE
fix(types): align execution result metadata with dispatch contract

### DIFF
--- a/lib/commanded/commands/execution_result.ex
+++ b/lib/commanded/commands/execution_result.ex
@@ -25,7 +25,7 @@ defmodule Commanded.Commands.ExecutionResult do
           aggregate_state: struct,
           aggregate_version: non_neg_integer(),
           events: list(struct()),
-          metadata: struct()
+          metadata: map()
         }
 
   @enforce_keys [:aggregate_uuid, :aggregate_state, :aggregate_version, :events, :metadata]


### PR DESCRIPTION
- Keeps the execution result typespec aligned with the value actually built from dispatch metadata so static analysis reflects the public API accurately
- Avoids leaking a misleading struct-shaped metadata contract into callers when the implementation and tests use a map