### PR TITLE
fix(subscriptions): avoid races in teardown assertions

### DIFF
--- a/test/subscriptions/subscriptions_test.exs
+++ b/test/subscriptions/subscriptions_test.exs
@@ -23,13 +23,12 @@ defmodule Commanded.SubscriptionsTest do
     end
 
     test "should not remove PID when process terminates" do
-      pid =
-        spawn_link(fn ->
+      {pid, ref} =
+        spawn_monitor(fn ->
           :ok = Subscriptions.register(DefaultApp, "handler1", Handler1, :strong)
         end)
 
-      ref = Process.monitor(pid)
-      assert_receive {:DOWN, ^ref, :process, _, :normal}
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
 
       assert Subscriptions.all(DefaultApp) == [{"handler1", Handler1, pid}]
     end


### PR DESCRIPTION
- keep the subscriptions suite focused on registry behavior instead of monitor timing
- remove a source of non-determinism from the full test run so failures reflect real regressions