### PR TITLE
fix(github): pin release-please-action to commit SHA

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: release
         name: Release
-        uses: googleapis/release-please-action@v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json


### PR DESCRIPTION
- The org-level Actions policy requires all actions to be pinned to a full-length commit SHA; using a tag like `v4.2.0` caused the workflow to be blocked