### PR TITLE
test(opentelemetry): avoid exporter startup races

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,9 @@ config :ex_unit,
   capture_log: [level: :debug],
   exclude: [:distributed, :eventstore_adapter]
 
-config :opentelemetry, processors: []
+config :opentelemetry,
+  processors: [],
+  traces_exporter: :none
 
 config :commanded,
   assert_receive_event_timeout: 100,

--- a/test/support/opentelemetry_case.ex
+++ b/test/support/opentelemetry_case.ex
@@ -27,6 +27,7 @@ defmodule Commanded.OpenTelemetryCase do
   setup do
     :application.stop(:opentelemetry)
     :application.set_env(:opentelemetry, :tracer, :otel_tracer_default)
+    :application.set_env(:opentelemetry, :traces_exporter, :none)
 
     :application.set_env(:opentelemetry, :processors, [
       {:otel_batch_processor, %{scheduled_delay_ms: 1}}


### PR DESCRIPTION
- keep OpenTelemetry tests from booting an unintended OTLP exporter before switching to the PID exporter
- remove noisy startup failures that make distributed and full-suite runs harder to trust when tracing tests restart the SDK repeatedly
- keep the existing exporter handoff behavior while making the test environment deterministic