### PR TITLE
test(eventstore): silence expected disconnect chatter

### DIFF
--- a/test/aggregates/snapshotting_postgres_test.exs
+++ b/test/aggregates/snapshotting_postgres_test.exs
@@ -14,6 +14,7 @@ defmodule Commanded.Aggregates.SnapshottingPostgresTest do
   alias Commanded.Aggregates.ExampleAggregate.Commands.AppendItems
   alias Commanded.EventStore
   alias Commanded.EventStore.SnapshotData
+  alias Commanded.TestSupport.ModuleLoggerLevelHelpers
   alias Commanded.UUID
 
   defmodule App do
@@ -25,6 +26,12 @@ defmodule Commanded.Aggregates.SnapshottingPostgresTest do
       ],
       pubsub: :local,
       registry: :local
+  end
+
+  setup_all do
+    ModuleLoggerLevelHelpers.suppress_module_log_level(DBConnection.Connection, :warning)
+
+    :ok
   end
 
   setup do

--- a/test/event_store/adapters/event_store/event_store_prefix_test.exs
+++ b/test/event_store/adapters/event_store/event_store_prefix_test.exs
@@ -6,8 +6,15 @@ defmodule Commanded.EventStore.Adapters.EventStore.EventStorePrefixTest do
 
   alias Commanded.EventStore.Adapters.EventStore.Storage
   alias Commanded.EventStore.EventStoreTestCase
+  alias Commanded.TestSupport.ModuleLoggerLevelHelpers
   alias EventStore.Tasks.Create
   alias EventStore.Tasks.Init
+
+  setup_all do
+    ModuleLoggerLevelHelpers.suppress_module_log_level(DBConnection.Connection, :warning)
+
+    :ok
+  end
 
   setup_all do
     config1 = Storage.config("prefix1")

--- a/test/event_store/adapters/event_store/event_store_test.exs
+++ b/test/event_store/adapters/event_store/event_store_test.exs
@@ -3,6 +3,14 @@ defmodule Commanded.EventStore.Adapters.EventStore.EventStoreTest do
 
   @moduletag :eventstore_adapter
 
+  alias Commanded.TestSupport.ModuleLoggerLevelHelpers
+
+  setup_all do
+    ModuleLoggerLevelHelpers.suppress_module_log_level(DBConnection.Connection, :warning)
+
+    :ok
+  end
+
   setup do
     start_supervised!(EventStoreApplication)
 

--- a/test/opentelemetry/application_e2e_test.exs
+++ b/test/opentelemetry/application_e2e_test.exs
@@ -7,6 +7,7 @@ defmodule Commanded.OpenTelemetry.ApplicationE2ETest do
   alias Commanded.OpenTelemetry.Aggregate, as: OTelAggregate
   alias Commanded.OpenTelemetry.Application, as: OTelApplication
   alias Commanded.OpenTelemetry.EventHandler, as: OTelEventHandler
+  alias Commanded.TestSupport.ModuleLoggerLevelHelpers
   alias Commanded.UUID
 
   require OpenTelemetry.Tracer, as: Tracer
@@ -44,6 +45,12 @@ defmodule Commanded.OpenTelemetry.ApplicationE2ETest do
       name: __MODULE__
 
     def handle(_event, _metadata), do: :ok
+  end
+
+  setup_all do
+    ModuleLoggerLevelHelpers.suppress_module_log_level(DBConnection.Connection, :warning)
+
+    :ok
   end
 
   setup do

--- a/test/support/event_store_test_case.ex
+++ b/test/support/event_store_test_case.ex
@@ -3,6 +3,13 @@ defmodule Commanded.EventStore.EventStoreTestCase do
 
   alias Commanded.EventStore.Adapters.EventStore
   alias Commanded.EventStore.Adapters.EventStore.Storage
+  alias Commanded.TestSupport.ModuleLoggerLevelHelpers
+
+  setup_all do
+    ModuleLoggerLevelHelpers.suppress_module_log_level(DBConnection.Connection, :warning)
+
+    :ok
+  end
 
   setup_all do
     config = Storage.config()

--- a/test/support/module_logger_level_helpers.ex
+++ b/test/support/module_logger_level_helpers.ex
@@ -1,0 +1,25 @@
+defmodule Commanded.TestSupport.ModuleLoggerLevelHelpers do
+  @moduledoc false
+
+  import ExUnit.Callbacks
+
+  require Logger
+
+  def suppress_module_log_level(module, level) do
+    previous_level = Logger.get_module_level(module)
+    Logger.put_module_level(module, level)
+
+    on_exit(fn ->
+      restore_module_log_level(module, previous_level)
+    end)
+
+    :ok
+  end
+
+  defp restore_module_log_level(module, []), do: Logger.delete_module_level(module)
+
+  defp restore_module_log_level(module, [{logged_module, level}])
+       when logged_module == module do
+    Logger.put_module_level(module, level)
+  end
+end


### PR DESCRIPTION
- keep adapter-backed test runs from drowning in expected connection teardown noise
- scope the logger suppression to the DBConnection path that emits informational disconnect messages while preserving warnings and errors
- make the full adapter-inclusive suite easier to trust by leaving only unexpected failures visible